### PR TITLE
Fix paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "homepage": "https://github.com/mfikes/andare",
   "license": "EPL-1.0",
   "directories": {
-    "lib": "src"
+    "lib": "src/main/clojure"
   },
   "files": [
-    "src/*"
+    "src/main/clojure/*"
   ],
   "keywords": [
     "clojurescript",


### PR DESCRIPTION
Apologetically using the right path to the Clojure source in package.json.

In order to try it out:

```
cat > package.json
{
  "dependencies": {}
}
^D
...
npm install /folder/where/you/have/andare
lumo

cljs.user=> (require '[cljs.core.async :as async :refer [go <! >!]])
nil
```